### PR TITLE
Added support for less arrays

### DIFF
--- a/index.js
+++ b/index.js
@@ -11,14 +11,23 @@ module.exports = function(options) {
         if (file.isStream()) {
             return cb(new gutil.PluginError("gulp-less-variables", "Streaming not supported"));
         }
-        var varible = [];
+        var variable = [];
+        var value;
         for (var v in options) {
-            varible.push("@" + v + ": '" + options[v] + "';\n");
+            value = options[v];
+            if (Array.isArray(value)) {
+                value = value.map(function(v){
+                    return "'" + v + "'";
+                }).join(', ');
+            } else {
+                value = "'" + v + "'";
+            }
+            variable.push("@" + v + ": " + value + ";\n");
         }
-        varible = varible.join("\n\n\n");
+        variable = variable.join("\n\n\n");
         // Return file
         var str = file.contents.toString('utf8');
-        file.contents = new Buffer(varible + str);
+        file.contents = new Buffer(variable + str);
         cb(null, file);
     });
 };


### PR DESCRIPTION
The following variable configuration:

```
{
  angle: '135deg',
  colors: ['#000000', '#ffffff', '#acacac']
}
```

should output:

```
@angle: '135deg'; // works already
@colors: '#000000', '#ffffff', '#acacac'; // currently does not work as expected.
```

Also, fixed a typo `varible` -> `variable` :)
